### PR TITLE
bump grunt-lib-phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "chalk": "1.1.1",
-    "grunt-lib-phantomjs": "0.7.1",
+    "grunt-lib-phantomjs": "1.0.1",
     "jasmine-core": "2.4.1",
     "minimatch": "3.0.0",
     "underscore": "1.8.3",


### PR DESCRIPTION
This brings support for modern PhantomJS releases as per https://github.com/gruntjs/grunt-lib-phantomjs/blob/master/CHANGELOG
