### PR TITLE
fix specFiles entry for non-"*.js" files

### DIFF
--- a/tasks/jasmine_webpack.js
+++ b/tasks/jasmine_webpack.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
             // Filter out any spec files that don't match the filter.
             if (!fileFilter || minimatch(f, fileFilter, {matchBase: true})) {
                 specFiles.push(
-                    path.relative(outdir, path.join(tempDir + '/specs', path.basename(f)))
+                    path.relative(outdir, path.join(tempDir + '/specs', filename + ".js"))
                 );
                 entries[filename] = f;
             }


### PR DESCRIPTION
When using this with spec files written in coffeescript no tests are found. The template is including `/.git/grunt-jasmine-webpack/*.coffee` when the actual output names are `*.coffee.js`. The attached fix should solve this issue for all inputs that arent `*.js`
