### PR TITLE
Pull spec files from webpack stats

### DIFF
--- a/tasks/jasmine_webpack.js
+++ b/tasks/jasmine_webpack.js
@@ -54,8 +54,7 @@ module.exports = function (grunt) {
                 }
             }),
 
-            entries = {},
-            specFiles = [];
+            entries = {};
 
         if (filter) {
             filter = filter.split(':');
@@ -74,14 +73,11 @@ module.exports = function (grunt) {
 
             // Filter out any spec files that don't match the filter.
             if (!fileFilter || minimatch(f, fileFilter, {matchBase: true})) {
-                specFiles.push(
-                    path.relative(outdir, path.join(tempDir + '/specs', filename + ".js"))
-                );
                 entries[filename] = f;
             }
         });
 
-        if (specFiles.length === 0) {
+        if (Object.keys(entries).length === 0) {
             grunt.log.error('No tests found');
             done(false);
         }
@@ -146,7 +142,10 @@ module.exports = function (grunt) {
                         return path.relative(outdir, path.join(tempDir, basename));
                     })),
                     scripts: {
-                        specs: specFiles,
+                        specs: Object.keys(stats.compilation.assets)
+                            .map(function(key) { return stats.compilation.assets[key] })
+                            .filter(function(asset) { return asset.emitted })
+                            .map(function(asset) { return asset.existsAt }),
 
                         jasmine: jasmine.files.jsFiles.map(function (jsFile) {
                             return path.relative(outdir, path.join(tempDir, jsFile));


### PR DESCRIPTION
To resolve #14 

Tests seem to pass (or fail) as expected.

One thing I'm not 100% clear on is if an entry imports additional modules, do those show up in the `stats.compilation.assets` object? If so, they'll need to be filtered out. I'm going to be converting my actual tests over today and I should see from that if there needs to be additional tweaking
