### PR TITLE
Adding functionality to make test result and summary output optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ Type: `Object`
 
 Any extra options that should be passed to the template file. Note that if no template file is given these will be ignored.
 
+#### display
+
+Type: `String`
+
+    * `full` Displays full test description and results
+    * `short` Displays short characters to represent test results
+    * `none` Does not display any test results
+
+Defaults to `'full'`
+
+#### summary
+
+Type: `Boolean`
+
+Will display a count of all passed, failed, and skipped tests
+
+Defaults to `true`
+
 ### Usage examples
 
 ```javascript

--- a/tasks/lib/Reporter.js
+++ b/tasks/lib/Reporter.js
@@ -41,36 +41,48 @@ _.extend(Reporter.prototype, {
         }
     },
 
-    reportSpec: function (description, skipped, passedExpectations, failedExpectations) {
+    reportSpec: function (description, skipped, passedExpectations, failedExpectations, display) {
         this.indentLevel++;
 
         if (skipped) {
-            this.grunt.log.writeln(
-                indent(this.indentLevel) +
-                chalk.yellow("SKIPPED: ") +
-                chalk.grey(description)
-            );
+            if (display === 'full') {
+                this.grunt.log.writeln(
+                    indent(this.indentLevel) +
+                    chalk.yellow("SKIPPED: ") +
+                    chalk.grey(description)
+                );
+            } else if (display === 'short') {
+                this.grunt.log.write(chalk.yellow("*"));
+            }
         }
 
         passedExpectations.forEach(function () {
-            this.grunt.log.writeln(
-                indent(this.indentLevel) +
-                chalk.green("PASS: ") +
-                chalk.gray(description)
-            );
+            if (display === 'full') {
+                this.grunt.log.writeln(
+                    indent(this.indentLevel) +
+                    chalk.green("PASS: ") +
+                    chalk.gray(description)
+                );
+            } else if (display === 'short') {
+                this.grunt.log.write(chalk.green("."));
+            }
         }, this);
 
         failedExpectations.forEach(function (expectation) {
-            this.grunt.log.writeln(
-                indent(this.indentLevel) +
-                chalk.red("FAIL: ") +
-                chalk.gray(description)
-            );
+            if (display === 'full') {
+                this.grunt.log.writeln(
+                    indent(this.indentLevel) +
+                    chalk.red("FAIL: ") +
+                    chalk.gray(description)
+                );
 
-            this.grunt.log.writeln(
-                indent(this.indentLevel) +
-                chalk.red(expectation.message)
-            );
+                this.grunt.log.writeln(
+                    indent(this.indentLevel) +
+                    chalk.red(expectation.message)
+                );
+            } else if (display === 'short') {
+                this.grunt.log.write(chalk.red("X"));
+            }
         }, this);
 
         this.indentLevel--;


### PR DESCRIPTION
This addresses issue #16 

This is an implementation of the display options in [grunt-contrib-jasmine](https://github.com/gruntjs/grunt-contrib-jasmine/blob/master/README.md#optionsdisplay).

In short, this will allow us to define whether we want full, short, or no test reporting output. Please review at your earliest convenience, thank you.
