### PR TITLE
Allow Grunt task to override PhantomJS's default timeout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,19 @@ module.exports = function (grunt) {
                     display: 'short'
                 },
                 src: 'example/**/*.js'
+            },
+            timeout: {
+                options: {
+                    webpack: {
+                        resolve: {
+                            modules: [
+                                path.join(__dirname, './')
+                            ]
+                        }
+                    },
+                    timeout: 10000
+                },
+                src: 'example/**/*.js'
             }
         }
     });

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Will display a count of all passed, failed, and skipped tests
 
 Defaults to `true`
 
+#### timeout
+
+Type: `Number`
+
+Number of milliseconds for PhantomJS to wait before timing out and failing the suite.
+
+Defaults to `5000`
+
 ### Usage examples
 
 ```javascript

--- a/tasks/jasmine_webpack.js
+++ b/tasks/jasmine_webpack.js
@@ -39,7 +39,8 @@ module.exports = function (grunt) {
                 vendor: [],
                 polyfills: [promisePolyfillPath],
                 display: 'full',
-                summary: true
+                summary: true,
+                timeout: null
             }),
 
             filter = grunt.option('filter'),
@@ -198,6 +199,9 @@ module.exports = function (grunt) {
 
                 // Run tests in phantomjs, if options.norun is false.
                 phantomjs.spawn(options.specRunnerDest, {
+                    options: {
+                        timeout: options.timeout
+                    },
                     done: function () {
                         // Clean up.
                         if (!options.keepRunner) {


### PR DESCRIPTION
Was debugging some very large test suites where Jasmine was not
receiving the window.onload event in time - PhantomJS first timed
out. If you have a big app then every spec file can end up large, so
I think this is just time to load.